### PR TITLE
fix: server-side rendering

### DIFF
--- a/.changeset/famous-flies-cover.md
+++ b/.changeset/famous-flies-cover.md
@@ -1,0 +1,5 @@
+---
+"@adhese/sdk-react": patch
+---
+
+Fix SSR useLayoutEffect

--- a/packages/sdk-react/src/useAdheseSlot.ts
+++ b/packages/sdk-react/src/useAdheseSlot.ts
@@ -2,14 +2,14 @@ import type { AdheseSlot, AdheseSlotOptions } from '@adhese/sdk';
 import { generateSlotSignature, watch, type WatchHandle, type WatchOptions } from '@adhese/sdk-shared';
 import {
   type RefObject,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useState,
-  useEffect,
 } from 'react';
 import { useAdhese } from './adheseContext';
 
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
 /**
  * Hook to create an Adhese slot. The slot will be disposed when the component is unmounted. The slot will be created

--- a/packages/sdk-react/src/useAdheseSlot.ts
+++ b/packages/sdk-react/src/useAdheseSlot.ts
@@ -5,8 +5,11 @@ import {
   useLayoutEffect,
   useMemo,
   useState,
+  useEffect,
 } from 'react';
 import { useAdhese } from './adheseContext';
+
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 /**
  * Hook to create an Adhese slot. The slot will be disposed when the component is unmounted. The slot will be created
@@ -29,7 +32,7 @@ export function useAdheseSlot(elementRef: RefObject<HTMLElement> | string, optio
 
   const [slot, setSlot] = useState<AdheseSlot | null>(null);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const element = typeof elementRef === 'string' ? elementRef : elementRef.current;
 
     if (adhese && element) {
@@ -56,7 +59,7 @@ export function useWatch<
 >(value?: Input, options?: Omit<WatchOptions, 'immediate'>): Output {
   const [state, setState] = useState<Output>(typeof value === 'function' ? value() : value);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     let handle: WatchHandle | undefined;
 
     if (value) {


### PR DESCRIPTION
Fix for 

> Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.

When the component is first server-side rendered