### PR TITLE
Additional Tracker added

### DIFF
--- a/.changeset/thin-forks-type.md
+++ b/.changeset/thin-forks-type.md
@@ -1,0 +1,5 @@
+---
+"@adhese/sdk": minor
+---
+
+Added an additional tracker on AdheseAd that will be fired together with the impressions tracker.

--- a/packages/sdk/src/requestAds/requestAds.schema.ts
+++ b/packages/sdk/src/requestAds/requestAds.schema.ts
@@ -43,6 +43,7 @@ const baseSchema = object({
   height: numberLike.optional(),
   id: string().optional(),
   impressionCounter: urlLike.optional(),
+  additonalTracker: urlLike.optional(),
   libId: string().optional(),
   orderId: string().optional(),
   orderName: string().optional(),

--- a/packages/sdk/src/slot/slot.test.ts
+++ b/packages/sdk/src/slot/slot.test.ts
@@ -211,6 +211,39 @@ describe('slot', () => {
     expect(slot.element).not.toBe(null);
   });
 
+  it('should be able to render a slot with an additional tracker', async () => {
+    const element = document.createElement('div');
+
+    element.classList.add('adunit');
+    element.dataset.format = 'leaderboard';
+    element.id = 'leaderboard';
+
+    document.body.appendChild(element);
+
+    const slot = createSlot({
+      format: 'leaderboard',
+      containingElement: 'leaderboard',
+      context,
+    });
+
+    await awaitTimeout(0);
+
+    await slot.render({
+      adFormat: 'foo',
+      tag: '<div>foo</div>',
+      // eslint-disable-next-line ts/naming-convention
+      slotID: 'bar',
+      slotName: 'baz',
+      adType: 'foo',
+      impressionCounter: new URL('https://foo.bar'),
+      additonalTracker: new URL('https://foo2.bar'),
+      id: 'baz',
+      origin: 'JERLICIA',
+    });
+
+    expect(slot.element).not.toBe(null);
+  });
+
   it('should be able generate a slot name', async () => {
     expect((createSlot({
       format: 'bar',


### PR DESCRIPTION
Hey guys, 

We added an additional tracker on the AdAdhese object in order to be able to populate this from a hook. 
The idea is to add an extra tracker from the implementation code. 
This will be used in the USA for tracking DALE responses in the same way as the JERLICIA responses.

Thanks for the review! 

Kevin