### PR TITLE
fix(ci): don't run nightly publish on the release PR

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -171,13 +171,25 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Nightly mode: pull request to main
+      # Skipped on the Changesets release PR: its changesets are already consumed, so
+      # `changeset version --snapshot` is a no-op there and the following publish would
+      # push the real release version under the nightly tag, making the release run on
+      # main a no-op (no git tags, no GitHub release, no `latest` tag on npm).
       - name: Generate changelog
-        if: github.event_name == 'pull_request'
-        run: npm run changeset version -- --snapshot nightly
+        id: nightly-version
+        if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
+        run: |
+          npm run changeset version -- --snapshot nightly
+          if git diff --name-only -- ':(glob)**/package.json' | grep -q .; then
+            echo 'hasSnapshot=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'No changesets in this PR, skipping nightly publish' >> "$GITHUB_STEP_SUMMARY"
+            echo 'hasSnapshot=false' >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Publish nightly
         id: publish-nightly
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.nightly-version.outputs.hasSnapshot == 'true'
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           publish: npm run changeset publish -- --snapshot --tag nightly
@@ -186,7 +198,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment on PR with nightly build info
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.nightly-version.outputs.hasSnapshot == 'true'
         run: npx tsx ./scripts/nightlyGithubAction.ts --packages '${{ steps.publish-nightly.outputs.publishedPackages }}' --pull-request ${{ github.event.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes [SUP-351](https://adhese.atlassian.net/browse/SUP-351).

## Problem

Releases stopped showing up in GitHub: the latest release is `@adhese/sdk@1.11.5` (2026-05-07) while npm has 1.11.6 and 1.11.7. There are also no git tags for those two versions, and `npm view @adhese/sdk dist-tags` still returns `latest: 1.11.5` — so `npm i @adhese/sdk` installs 1.11.5, not 1.11.7.

## Root cause

The `pull_request` (nightly) path of `publish.yaml` also runs on the Changesets release PR (`changeset-release/main`):

1. `changeset version --snapshot nightly` → `warn No unreleased changesets found, exiting.` — the release PR already consumed them, so no snapshot version is generated and the versions stay at the real release version.
2. `changeset publish --snapshot --tag nightly` → publishes the **real** version (1.11.7) to npm under the `nightly` dist-tag. Log of run [29725601777](https://github.com/adhese/sdk_typescript/actions/runs/29725601777): `info Publishing "@adhese/sdk" at "1.11.7"`.
3. The PR is merged, the release run on main executes `changeset publish` and finds `@adhese/sdk is not being published because version 1.11.7 is already published on npm` → `No unpublished projects to publish`.
4. `changesets/action` therefore sets `published: false`, which skips `git push --follow-tags`, the GitHub release creation, the GitHub Packages publish and the docs deploy. The git tags created in step 2 lived only on the PR runner and were never pushed.

Same thing happened for 1.11.6 (release PR #314), which is why it has been stuck for two releases.

## Fix

- Skip the nightly steps when the PR is the Changesets release PR (`github.head_ref != 'changeset-release/main'`).
- As a second guard, only publish a nightly when `changeset version --snapshot` actually bumped a `package.json`, so a PR without changesets can never publish a real version under the nightly tag either.

## Follow-up (not in this PR, needs npm/repo write access)

- `npm dist-tag add @adhese/sdk@1.11.7 latest` and `npm dist-tag add @adhese/sdk-react@1.11.7 latest` — `latest` is still 1.11.5.
- Backfill the missing git tags + GitHub releases for `@adhese/sdk@1.11.6`, `@adhese/sdk-react@1.11.6` (commit 4e3e811), `@adhese/sdk@1.11.7`, `@adhese/sdk-react@1.11.7` (commit 70b9dd8).
- 1.11.6/1.11.7 were never published to GitHub Packages either (that step is also gated on `published == 'true'`).